### PR TITLE
Support overriding crashTypeId

### DIFF
--- a/BugSplatDotNetStandard.Test/BugSplat.cs
+++ b/BugSplatDotNetStandard.Test/BugSplat.cs
@@ -19,9 +19,9 @@ namespace Tests
             catch (Exception ex)
             {
                 var sut = new BugSplat("fred", "MyDotNetStandardCrasher", "1.0");
-
-                var options = new BugSplatPostOptions()
+                var options = new ExceptionPostOptions()
                 {
+                    ExceptionType = BugSplat.ExceptionTypeId.DotNetStandard,
                     Description = "BugSplat rocks!",
                     Email = "fred@bugsplat.com",
                     User = "Fred",
@@ -39,11 +39,10 @@ namespace Tests
         public void BugSplat_PostMinidump_ShouldPostMinidumpToBugSplat()
         {
             var sut = new BugSplat("fred", "myConsoleCrasher", "2021.4.23.0");
-
             var minidumpFileInfo = new FileInfo("minidump.dmp");
-            // TODO BG https://github.com/BugSplat-Git/webroot/issues/459
-            var options = new BugSplatPostOptions()
+            var options = new MinidumpPostOptions()
             {
+                MinidumpType = BugSplat.MinidumpTypeId.UnityNativeWindows,
                 Description = "BugSplat rocks!",
                 Email = "fred@bugsplat.com",
                 User = "Fred",

--- a/BugSplatDotNetStandard/BugSplatPostOptions.cs
+++ b/BugSplatDotNetStandard/BugSplatPostOptions.cs
@@ -2,10 +2,27 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using static BugSplatDotNetStandard.BugSplat;
 
 namespace BugSplatDotNetStandard
 {
-    public class BugSplatPostOptions
+    public class ExceptionPostOptions: BugSplatPostOptions
+    {
+        /// <summary>
+        /// An exception type to be added to the post that overrides the corresponding default values
+        /// </summary>
+        public ExceptionTypeId ExceptionType { get; set; }
+    }
+
+    public class MinidumpPostOptions: BugSplatPostOptions
+    {
+        /// <summary>
+        /// A minidump type to be added to the post that overrides the corresponding default values
+        /// </summary>
+        public MinidumpTypeId MinidumpType { get; set; }
+    }
+
+    public abstract class BugSplatPostOptions
     {
         /// <summary>
         /// A list of attachments to be added to the post
@@ -16,7 +33,7 @@ namespace BugSplatDotNetStandard
         /// A list of form data key value pairs to be added to the post
         /// </summary>
         public List<FormDataParam> AdditionalFormDataParams { get; } = new List<FormDataParam>();
-        
+
         /// <summary>
         /// A description to be added to the post that overrides the corresponding default value
         /// </summary>


### PR DESCRIPTION
This allows us to specify how the exception or minidump should be treated by the backend.

Fixes #14