### PR TITLE
Fix crash type overrides

### DIFF
--- a/BugSplatDotNetStandard.Test/BugSplat.cs
+++ b/BugSplatDotNetStandard.Test/BugSplat.cs
@@ -43,7 +43,6 @@ namespace Tests
             sut.MinidumpType = BugSplat.MinidumpTypeId.UnityNativeWindows;
             var options = new MinidumpPostOptions()
             {
-                //MinidumpType = BugSplat.MinidumpTypeId.UnityNativeWindows,
                 Description = "BugSplat rocks!",
                 Email = "fred@bugsplat.com",
                 User = "Fred",

--- a/BugSplatDotNetStandard.Test/BugSplat.cs
+++ b/BugSplatDotNetStandard.Test/BugSplat.cs
@@ -21,7 +21,7 @@ namespace Tests
                 var sut = new BugSplat("fred", "MyDotNetStandardCrasher", "1.0");
                 var options = new ExceptionPostOptions()
                 {
-                    ExceptionType = BugSplat.ExceptionTypeId.DotNetStandard,
+                    ExceptionType = BugSplat.ExceptionTypeId.Unity,
                     Description = "BugSplat rocks!",
                     Email = "fred@bugsplat.com",
                     User = "Fred",
@@ -40,9 +40,10 @@ namespace Tests
         {
             var sut = new BugSplat("fred", "myConsoleCrasher", "2021.4.23.0");
             var minidumpFileInfo = new FileInfo("minidump.dmp");
+            sut.MinidumpType = BugSplat.MinidumpTypeId.UnityNativeWindows;
             var options = new MinidumpPostOptions()
             {
-                MinidumpType = BugSplat.MinidumpTypeId.UnityNativeWindows,
+                //MinidumpType = BugSplat.MinidumpTypeId.UnityNativeWindows,
                 Description = "BugSplat rocks!",
                 Email = "fred@bugsplat.com",
                 User = "Fred",

--- a/BugSplatDotNetStandard/BugSplat.cs
+++ b/BugSplatDotNetStandard/BugSplat.cs
@@ -90,7 +90,7 @@ namespace BugSplatDotNetStandard
                 var uri = new Uri($"https://{database}.bugsplat.com/post/dotnetstandard/");
                 var callstack = ex.ToString();
                 var body = CreateMultiPartFormDataContent(options);
-                var crashTypeId = options?.ExceptionType != null ? options.ExceptionType : ExceptionType;
+                var crashTypeId = options?.ExceptionType != ExceptionTypeId.Unknown ? options.ExceptionType : ExceptionType;
                 body.Add(new StringContent(callstack), "callstack");
                 body.Add(new StringContent($"{(int)crashTypeId}"), "crashTypeId");
 
@@ -108,7 +108,7 @@ namespace BugSplatDotNetStandard
             using (var httpClient = new HttpClient())
             {
                 var uri = new Uri($"https://{database}.bugsplat.com/api/upload/manual/crash.php");
-                var crashTypeId = options?.MinidumpType != null ? options.MinidumpType : MinidumpType;
+                var crashTypeId = options?.MinidumpType != MinidumpTypeId.Unknown ? options.MinidumpType : MinidumpType;
                 var minidump = File.ReadAllBytes(minidumpFileInfo.FullName);
                 var body = CreateMultiPartFormDataContent(options);
                 body.Add(new ByteArrayContent(minidump), "minidump", "minidump.dmp");

--- a/BugSplatDotNetStandard/BugSplatPostOptions.cs
+++ b/BugSplatDotNetStandard/BugSplatPostOptions.cs
@@ -11,7 +11,7 @@ namespace BugSplatDotNetStandard
         /// <summary>
         /// An exception type to be added to the post that overrides the corresponding default values
         /// </summary>
-        public ExceptionTypeId ExceptionType { get; set; }
+        public ExceptionTypeId ExceptionType { get; set; } = ExceptionTypeId.Unknown;
     }
 
     public class MinidumpPostOptions: BugSplatPostOptions
@@ -19,7 +19,7 @@ namespace BugSplatDotNetStandard
         /// <summary>
         /// A minidump type to be added to the post that overrides the corresponding default values
         /// </summary>
-        public MinidumpTypeId MinidumpType { get; set; }
+        public MinidumpTypeId MinidumpType { get; set; } = MinidumpTypeId.Unknown;
     }
 
     public abstract class BugSplatPostOptions


### PR DESCRIPTION
ExceptionPostOptions and MinidumpPostOptions were implemented without defaults for ExceptionType and MinidumpType respectively. The thought was that they would get initialized to null, but it turns out they get initialized to 0 and thus checking if they are equal to null will never work. We need to update them to override if the value is 0 (Unknown) instead and set the default value to Unknown.

Fixes #17