### PR TITLE
Update Unity ExceptionTypeId

### DIFF
--- a/BugSplatDotNetStandard.Test/BugSplat.cs
+++ b/BugSplatDotNetStandard.Test/BugSplat.cs
@@ -18,7 +18,7 @@ namespace Tests
             }
             catch (Exception ex)
             {
-                var sut = new BugSplat("fred", "MyDotNetStandardCrasher", "1.0");
+                var sut = new BugSplat("octomore", "MyDotNetStandardCrasher", "1.0");
                 var options = new ExceptionPostOptions()
                 {
                     ExceptionType = BugSplat.ExceptionTypeId.Unity,

--- a/BugSplatDotNetStandard.Test/BugSplat.cs
+++ b/BugSplatDotNetStandard.Test/BugSplat.cs
@@ -18,7 +18,7 @@ namespace Tests
             }
             catch (Exception ex)
             {
-                var sut = new BugSplat("octomore", "MyDotNetStandardCrasher", "1.0");
+                var sut = new BugSplat("fred", "MyDotNetStandardCrasher", "1.0");
                 var options = new ExceptionPostOptions()
                 {
                     ExceptionType = BugSplat.ExceptionTypeId.Unity,

--- a/BugSplatDotNetStandard/BugSplat.cs
+++ b/BugSplatDotNetStandard/BugSplat.cs
@@ -50,8 +50,8 @@ namespace BugSplatDotNetStandard
         public enum ExceptionTypeId
         {
             Unknown = 0,
-            Unity = 12,
-            DotNetStandard = 18
+            DotNetStandard = 18,
+            Unity = 24
         }
 
         public enum MinidumpTypeId


### PR DESCRIPTION
We added a new crash type id to the backend for Unity crashes captured by bugsplat-net-standard.

Fixes #19