### PR TITLE
Add support for posting stringified StackTrace

### DIFF
--- a/BugSplatDotNetStandard.Test/BugSplat.cs
+++ b/BugSplatDotNetStandard.Test/BugSplat.cs
@@ -41,7 +41,7 @@ namespace Tests
         }
 
         [Test]
-        public void BugSplat_PostMinidump_ShouldPostMinidumpToBugSplat()
+        public void BugSplat_Post_ShouldPostMinidumpToBugSplat()
         {
             var sut = new BugSplat("fred", "myConsoleCrasher", "2021.4.23.0");
             var minidumpFileInfo = new FileInfo("minidump.dmp");
@@ -60,6 +60,37 @@ namespace Tests
             };
             options.AdditionalAttachments.Add(new FileInfo("attachment.txt"));
             var response = sut.Post(minidumpFileInfo, options).Result;
+            var body = response.Content.ReadAsStringAsync().Result;
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Test]
+        public void BugSplat_Post_ShouldPostStackTraceToBugSplat()
+        {
+            var sut = new BugSplat("fred", "MyUnityCrasher", "1.0");
+            sut.ExceptionType = BugSplat.ExceptionTypeId.Unity;
+            sut.Description = "Default description - overridden";
+            sut.Email = "default@bugsplat.com - overridden";
+            sut.User = "Default - overridden";
+            sut.Key = "Default - overridden";
+            var stackTrace = @"Exception: BugSplat rocks!
+                Main.ThrowException () (at Assets/Main.cs:75)
+                Main.SampleStackFrame2 () (at Assets/Main.cs:95)
+                Main.SampleStackFrame1 () (at Assets/Main.cs:90)
+                Main.SampleStackFrame0 () (at Assets/Main.cs:85)
+                Main.GenerateSampleStackFramesAndThrow () (at Assets/Main.cs:80)
+                Main.Update() (at Assets/Main.cs:69)";
+            var options = new ExceptionPostOptions()
+            {
+                ExceptionType = BugSplat.ExceptionTypeId.UnityLegacy,
+                Description = "BugSplat rocks!",
+                Email = "fred@bugsplat.com",
+                User = "Fred",
+                Key = "the key!"
+            };
+            options.AdditionalAttachments.Add(new FileInfo("attachment.txt"));
+            var response = sut.Post(stackTrace, options).Result;
             var body = response.Content.ReadAsStringAsync().Result;
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);

--- a/BugSplatDotNetStandard/BugSplat.cs
+++ b/BugSplatDotNetStandard/BugSplat.cs
@@ -50,6 +50,7 @@ namespace BugSplatDotNetStandard
         public enum ExceptionTypeId
         {
             Unknown = 0,
+            UnityLegacy = 12,
             DotNetStandard = 18,
             Unity = 24
         }
@@ -81,23 +82,32 @@ namespace BugSplatDotNetStandard
         /// <summary>
         /// Post an Exception to BugSplat
         /// </summary>
-        /// <param name="ex">The Exception that will be serialized and posted to BugSplat</param>
+        /// <param name="stackTrace">A string representation of an Exception's stack trace</param>
         /// <param name="options">Optional parameters that will override the defaults if provided</param>
-        public async Task<HttpResponseMessage> Post(Exception ex, ExceptionPostOptions options = null)
+        public async Task<HttpResponseMessage> Post(string stackTrace, ExceptionPostOptions options = null)
         {
             using (var httpClient = new HttpClient())
             {
                 options = options ?? new ExceptionPostOptions();
 
                 var uri = new Uri($"https://{database}.bugsplat.com/post/dotnetstandard/");
-                var callstack = ex.ToString();
                 var body = CreateMultiPartFormDataContent(options);
                 var crashTypeId = options?.ExceptionType != ExceptionTypeId.Unknown ? options.ExceptionType : ExceptionType;
-                body.Add(new StringContent(callstack), "callstack");
+                body.Add(new StringContent(stackTrace), "callstack");
                 body.Add(new StringContent($"{(int)crashTypeId}"), "crashTypeId");
 
                 return await httpClient.PostAsync(uri, body);
             }
+        }
+
+        /// <summary>
+        /// Post an Exception to BugSplat
+        /// </summary>
+        /// <param name="ex">The Exception that will be serialized and posted to BugSplat</param>
+        /// <param name="options">Optional parameters that will override the defaults if provided</param>
+        public async Task<HttpResponseMessage> Post(Exception ex, ExceptionPostOptions options = null)
+        {
+            return await Post(ex.ToString(), options);
         }
 
         /// <summary>


### PR DESCRIPTION
Unity's LogMessageReceived callback gets passed an Exception that has
already been serialized. We should support this case as it may prove
useful elsewhere too.

Fixes #24