### PR TITLE
Added MinidumpTypeId for .NET

### DIFF
--- a/BugSplatDotNetStandard/BugSplat.cs
+++ b/BugSplatDotNetStandard/BugSplat.cs
@@ -58,6 +58,7 @@ namespace BugSplatDotNetStandard
         {
             Unknown = 0,
             WindowsNative = 1,
+            DotNet = 2,
             UnityNativeWindows = 15
         }
 
@@ -115,7 +116,7 @@ namespace BugSplatDotNetStandard
                 var crashTypeId = options?.MinidumpType != MinidumpTypeId.Unknown ? options.MinidumpType : MinidumpType;
                 var minidump = File.ReadAllBytes(minidumpFileInfo.FullName);
                 var body = CreateMultiPartFormDataContent(options);
-                body.Add(new ByteArrayContent(minidump), "minidump", "minidump.dmp");
+                body.Add(new ByteArrayContent(minidump), "minidump", minidumpFileInfo.Name);
                 body.Add(new StringContent($"{(int)crashTypeId}"), "crashTypeId");
 
                 return await httpClient.PostAsync(uri, body);


### PR DESCRIPTION
This indicates to the BugSplat backend the crash should be processed using our .NET minidump backend.

Fixes #26

Blocked by https://github.com/BugSplat-Git/src-backend/issues/141