### PR TITLE
Throws Argument Exceptions

### DIFF
--- a/BugSplatDotNetStandard.Test/BugSplat.cs
+++ b/BugSplatDotNetStandard.Test/BugSplat.cs
@@ -8,6 +8,23 @@ namespace Tests
 {
     public class BugSplatTest
     {
+        [Test]
+        public void BugSplat_Constructor_ShouldThrowIfDatabaseIsNull()
+        {
+            Assert.Throws<ArgumentException>(() => new BugSplat(null, "my-app", "1.0.0"));
+        }
+
+        [Test]
+        public void BugSplat_Constructor_ShouldThrowIfApplicationIsNull()
+        {
+            Assert.Throws<ArgumentException>(() => new BugSplat("fred", null, "1.0.0"));
+        }
+
+        [Test]
+        public void BugSplat_Constructor_ShouldThrowIfVersionIsNull()
+        {
+            Assert.Throws<ArgumentException>(() => new BugSplat("fred", "my-app", null));
+        }
 
         [Test]
         public void BugSplat_Post_ShouldPostExceptionToBugSplat()
@@ -41,6 +58,17 @@ namespace Tests
         }
 
         [Test]
+        public void BugSplat_Post_ShouldThrowIfExIsNull()
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                Exception ex = null;
+                var bugsplat = new BugSplat("fred", "my-app", "1.0.0");
+                await bugsplat.Post(ex);
+            });
+        }
+
+        [Test]
         public void BugSplat_Post_ShouldPostMinidumpToBugSplat()
         {
             var sut = new BugSplat("fred", "myConsoleCrasher", "2021.4.23.0");
@@ -63,6 +91,17 @@ namespace Tests
             var body = response.Content.ReadAsStringAsync().Result;
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Test]
+        public void BugSplat_Post_ShouldThrowIfMinidumpFileInfoIsNull()
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                FileInfo fileInfo = null;
+                var bugsplat = new BugSplat("fred", "my-app", "1.0.0");
+                await bugsplat.Post(fileInfo);
+            });
         }
 
         [Test]
@@ -94,6 +133,17 @@ namespace Tests
             var body = response.Content.ReadAsStringAsync().Result;
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Test]
+        public void BugSplat_Post_ShouldThrowIfStackTraceFileInfoIsNull()
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                string stackTrace = null;
+                var bugsplat = new BugSplat("fred", "my-app", "1.0.0");
+                await bugsplat.Post(stackTrace);
+            });
         }
     }
 

--- a/BugSplatDotNetStandard/BugSplat.cs
+++ b/BugSplatDotNetStandard/BugSplat.cs
@@ -74,6 +74,10 @@ namespace BugSplatDotNetStandard
         /// <param name="version">Your application's version (must match value used to upload symbols)</param>
         public BugSplat(string database, string application, string version)
         {
+            ThrowIfArgumentIsNullOrEmpty(database, "database");
+            ThrowIfArgumentIsNullOrEmpty(application, "application");
+            ThrowIfArgumentIsNullOrEmpty(version, "version");
+
             this.database = database;
             this.application = application;
             this.version = version;
@@ -86,6 +90,8 @@ namespace BugSplatDotNetStandard
         /// <param name="options">Optional parameters that will override the defaults if provided</param>
         public async Task<HttpResponseMessage> Post(string stackTrace, ExceptionPostOptions options = null)
         {
+            ThrowIfArgumentIsNull(stackTrace, "stackTrace");
+
             using (var httpClient = new HttpClient())
             {
                 options = options ?? new ExceptionPostOptions();
@@ -107,6 +113,8 @@ namespace BugSplatDotNetStandard
         /// <param name="options">Optional parameters that will override the defaults if provided</param>
         public async Task<HttpResponseMessage> Post(Exception ex, ExceptionPostOptions options = null)
         {
+            ThrowIfArgumentIsNull(ex, "ex");
+
             return await Post(ex.ToString(), options);
         }
 
@@ -117,6 +125,8 @@ namespace BugSplatDotNetStandard
         /// <param name="options">Optional parameters that will override the defaults if provided</param>
         public async Task<HttpResponseMessage> Post(FileInfo minidumpFileInfo, MinidumpPostOptions options = null)
         {
+            ThrowIfArgumentIsNull(minidumpFileInfo, "minidumpFileInfo");
+
             using (var httpClient = new HttpClient())
             {
                 options = options ?? new MinidumpPostOptions();
@@ -129,6 +139,22 @@ namespace BugSplatDotNetStandard
                 body.Add(new StringContent($"{(int)crashTypeId}"), "crashTypeId");
 
                 return await httpClient.PostAsync(uri, body);
+            }
+        }
+
+        private void ThrowIfArgumentIsNull(object argument, string name)
+        {
+            if (argument == null)
+            {
+                throw new ArgumentNullException($"{name} cannot be null!");
+            }
+        }
+
+        private void ThrowIfArgumentIsNullOrEmpty(string argument, string name)
+        {
+            if (string.IsNullOrEmpty(argument))
+            {
+                throw new ArgumentException($"{name} cannot be null or empty!");
             }
         }
 


### PR DESCRIPTION
Throws ArgumentNullExceptions and ArgumentExceptions if the values passed to methods don't match the defined contract. This makes debugging easier in environments such as bugsplat-unity.

Fixes #29