### PR TITLE
Post minidump files through AWS rather than directly to our endpoints

### DIFF
--- a/BugSplatDotNetStandard.Test/BugSplat.cs
+++ b/BugSplatDotNetStandard.Test/BugSplat.cs
@@ -87,7 +87,10 @@ namespace Tests
                 Key = "the key!"
             };
             options.AdditionalAttachments.Add(new FileInfo("attachment.txt"));
-            var response = sut.Post(minidumpFileInfo, options).Result;
+
+            var md5 = "B7AAAD5CD414C986C98B7560478DB0A2";
+            
+            var response = sut.Post(minidumpFileInfo, options, md5).Result;
             var body = response.Content.ReadAsStringAsync().Result;
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);

--- a/BugSplatDotNetStandard.Test/BugSplat.cs
+++ b/BugSplatDotNetStandard.Test/BugSplat.cs
@@ -88,9 +88,7 @@ namespace Tests
             };
             options.AdditionalAttachments.Add(new FileInfo("attachment.txt"));
 
-            var md5 = "B7AAAD5CD414C986C98B7560478DB0A2";
-            
-            var response = sut.Post(minidumpFileInfo, options, md5).Result;
+            var response = sut.Post(minidumpFileInfo, options).Result;
             var body = response.Content.ReadAsStringAsync().Result;
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);

--- a/BugSplatDotNetStandard.Test/BugSplatDotNetStandard.Test.csproj
+++ b/BugSplatDotNetStandard.Test/BugSplatDotNetStandard.Test.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
   </ItemGroup>
 

--- a/BugSplatDotNetStandard/BugSplat.cs
+++ b/BugSplatDotNetStandard/BugSplat.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -128,30 +129,30 @@ namespace BugSplatDotNetStandard
         /// </summary>
         /// <param name="ex">The minidump file that will be posted to BugSplat</param>
         /// <param name="options">Optional parameters that will override the defaults if provided</param>
-        public async Task<HttpResponseMessage> Post(FileInfo minidumpFileInfo, MinidumpPostOptions options = null, string md5 = "")
+        public async Task<HttpResponseMessage> Post(FileInfo minidumpFileInfo, MinidumpPostOptions options = null)
         {
             ThrowIfArgumentIsNull(minidumpFileInfo, "minidumpFileInfo");
 
             options = options ?? new MinidumpPostOptions();
 
-            var crashUploadResponse = await getCrashUploadUrl(minidumpFileInfo);
+            var crashUploadResponse = await GetCrashUploadUrl(minidumpFileInfo);
 
             ThrowIfHttpRequestFailed(crashUploadResponse);
 
-            var presignedUrl = await deserializeCrashUploadUrl(crashUploadResponse);
-            var uploadFileResponse = await uploadFileToPresignedURL(presignedUrl, minidumpFileInfo);
+            var presignedUrl = await ParseCrashUploadUrl(crashUploadResponse);
+            var uploadFileResponse = await UploadFileToPresignedURL(presignedUrl, minidumpFileInfo);
 
             ThrowIfHttpRequestFailed(uploadFileResponse);
 
-            var commitS3CrashResponse = await commitS3CrashUpload(presignedUrl.ToString(), options, md5);
+            var md5 = GetETagFromResponseHeaders(uploadFileResponse.Headers);
+            var commitS3CrashResponse = await CommitS3CrashUpload(presignedUrl.ToString(), options, md5);
 
             ThrowIfHttpRequestFailed(commitS3CrashResponse);
 
             return commitS3CrashResponse;
         }
 
-
-        private async Task<HttpResponseMessage> getCrashUploadUrl(FileInfo fileInfo)
+        private async Task<HttpResponseMessage> GetCrashUploadUrl(FileInfo fileInfo)
         {
             string path = $"{baseUrl}/api/getCrashUploadUrl";
             string route = $"{path}?database={database}&appName={application}&appVersion={version}&crashPostSize={fileInfo.Length}";
@@ -162,21 +163,28 @@ namespace BugSplatDotNetStandard
             }
         }
 
-        private async Task<Uri> deserializeCrashUploadUrl(HttpResponseMessage response)
+        private string GetETagFromResponseHeaders(HttpHeaders headers)
         {
-            var json = await response.Content.ReadAsStringAsync();
+            var etagQuoted = headers.GetValues("ETag").FirstOrDefault();
+            var etag = etagQuoted.Replace("\"", "");
+            return etag;
+        }
+
+        private async Task<Uri> ParseCrashUploadUrl(HttpResponseMessage response)
+        {
             try
             {
-                var awsResponse = JsonConvert.DeserializeObject<AWSResponse>(json);
-                return new Uri(awsResponse.Url);
+                var json = await response.Content.ReadAsStringAsync();
+                var presignedUrlResponse = JsonConvert.DeserializeObject<GetPresignedUrlResponse>(json);
+                return new Uri(presignedUrlResponse.Url);
             }
             catch
             {
-                throw new JsonException("Failed to deserialize crash upload url");
+                throw new JsonException("Failed to parse crash upload url");
             }
         }
 
-        private async Task<HttpResponseMessage> uploadFileToPresignedURL(Uri uri, FileInfo file)
+        private async Task<HttpResponseMessage> UploadFileToPresignedURL(Uri uri, FileInfo file)
         {
             using (var body = new MultipartFormDataContent())
             {
@@ -189,7 +197,7 @@ namespace BugSplatDotNetStandard
             }
         }
 
-        private async Task<HttpResponseMessage> commitS3CrashUpload(string s3Key, MinidumpPostOptions options, string md5 = "")
+        private async Task<HttpResponseMessage> CommitS3CrashUpload(string s3Key, MinidumpPostOptions options, string md5 = "")
         {
             using (var httpClient = new HttpClient())
             {

--- a/BugSplatDotNetStandard/BugSplat.cs
+++ b/BugSplatDotNetStandard/BugSplat.cs
@@ -2,8 +2,10 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using BugSplatDotNetStandard.Utils;
+using Newtonsoft.Json;
 
 namespace BugSplatDotNetStandard
 {
@@ -67,6 +69,8 @@ namespace BugSplatDotNetStandard
         private readonly string application;
         private readonly string version;
 
+        private string baseUrl => $"https://{database}.bugsplat.com";
+
         /// <summary>
         /// Post Exceptions and minidump files to BugSplat
         /// </summary>
@@ -97,7 +101,7 @@ namespace BugSplatDotNetStandard
             {
                 options = options ?? new ExceptionPostOptions();
 
-                var uri = new Uri($"https://{database}.bugsplat.com/post/dotnetstandard/");
+                var uri = new Uri($"{baseUrl}/post/dotnetstandard/");
                 var body = CreateMultiPartFormDataContent(options);
                 var crashTypeId = options?.ExceptionType != ExceptionTypeId.Unknown ? options.ExceptionType : ExceptionType;
                 body.Add(new StringContent(stackTrace), "callstack");
@@ -124,22 +128,80 @@ namespace BugSplatDotNetStandard
         /// </summary>
         /// <param name="ex">The minidump file that will be posted to BugSplat</param>
         /// <param name="options">Optional parameters that will override the defaults if provided</param>
-        public async Task<HttpResponseMessage> Post(FileInfo minidumpFileInfo, MinidumpPostOptions options = null)
+        public async Task<HttpResponseMessage> Post(FileInfo minidumpFileInfo, MinidumpPostOptions options = null, string md5 = "")
         {
             ThrowIfArgumentIsNull(minidumpFileInfo, "minidumpFileInfo");
 
+            options = options ?? new MinidumpPostOptions();
+
+            var crashUploadResponse = await getCrashUploadUrl(minidumpFileInfo);
+
+            ThrowIfHttpRequestFailed(crashUploadResponse);
+
+            var presignedUrl = await deserializeCrashUploadUrl(crashUploadResponse);
+            var uploadFileResponse = await uploadFileToPresignedURL(presignedUrl, minidumpFileInfo);
+
+            ThrowIfHttpRequestFailed(uploadFileResponse);
+
+            var commitS3CrashResponse = await commitS3CrashUpload(presignedUrl.ToString(), options, md5);
+
+            ThrowIfHttpRequestFailed(commitS3CrashResponse);
+
+            return commitS3CrashResponse;
+        }
+
+
+        private async Task<HttpResponseMessage> getCrashUploadUrl(FileInfo fileInfo)
+        {
+            string path = $"{baseUrl}/api/getCrashUploadUrl";
+            string route = $"{path}?database={database}&appName={application}&appVersion={version}&crashPostSize={fileInfo.Length}";
+
             using (var httpClient = new HttpClient())
             {
-                options = options ?? new MinidumpPostOptions();
+                return await httpClient.GetAsync(route);
+            }
+        }
 
-                var uri = new Uri($"https://{database}.bugsplat.com/api/upload/manual/crash.php");
+        private async Task<Uri> deserializeCrashUploadUrl(HttpResponseMessage response)
+        {
+            var json = await response.Content.ReadAsStringAsync();
+            try
+            {
+                var awsResponse = JsonConvert.DeserializeObject<AWSResponse>(json);
+                return new Uri(awsResponse.Url);
+            }
+            catch
+            {
+                throw new JsonException("Failed to deserialize crash upload url");
+            }
+        }
+
+        private async Task<HttpResponseMessage> uploadFileToPresignedURL(Uri uri, FileInfo file)
+        {
+            using (var body = new MultipartFormDataContent())
+            {
+                body.Add(new ByteArrayContent(File.ReadAllBytes(file.FullName)), "minidump");
+                using (var httpClient = new HttpClient())
+                {
+                    httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/octet-stream"));
+                    return await httpClient.PutAsync(uri, body);
+                }
+            }
+        }
+
+        private async Task<HttpResponseMessage> commitS3CrashUpload(string s3Key, MinidumpPostOptions options, string md5 = "")
+        {
+            using (var httpClient = new HttpClient())
+            {
+                var route = $"{baseUrl}/api/commitS3CrashUpload";
+
                 var crashTypeId = options?.MinidumpType != MinidumpTypeId.Unknown ? options.MinidumpType : MinidumpType;
-                var minidump = File.ReadAllBytes(minidumpFileInfo.FullName);
                 var body = CreateMultiPartFormDataContent(options);
-                body.Add(new ByteArrayContent(minidump), "minidump", minidumpFileInfo.Name);
                 body.Add(new StringContent($"{(int)crashTypeId}"), "crashTypeId");
+                body.Add(new StringContent(s3Key), "s3Key");
+                body.Add(new StringContent(md5), "md5");
 
-                return await httpClient.PostAsync(uri, body);
+                return await httpClient.PostAsync(route, body);
             }
         }
 
@@ -156,6 +218,14 @@ namespace BugSplatDotNetStandard
             if (string.IsNullOrEmpty(argument))
             {
                 throw new ArgumentException($"{name} cannot be null or empty!");
+            }
+        }
+
+        private void ThrowIfHttpRequestFailed(HttpResponseMessage response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException(response.Content.ReadAsStringAsync().Result);
             }
         }
 

--- a/BugSplatDotNetStandard/BugSplatDotNetStandard.csproj
+++ b/BugSplatDotNetStandard/BugSplatDotNetStandard.csproj
@@ -31,4 +31,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/BugSplatDotNetStandard/BugSplatPostOptions.cs
+++ b/BugSplatDotNetStandard/BugSplatPostOptions.cs
@@ -73,7 +73,7 @@ namespace BugSplatDotNetStandard
         public string FileName { get; set; } = string.Empty;
     }
 
-    internal class AWSResponse
+    internal class GetPresignedUrlResponse
     {
         public string Url;
     }

--- a/BugSplatDotNetStandard/BugSplatPostOptions.cs
+++ b/BugSplatDotNetStandard/BugSplatPostOptions.cs
@@ -72,4 +72,10 @@ namespace BugSplatDotNetStandard
         /// </summary>
         public string FileName { get; set; } = string.Empty;
     }
+
+    internal class AWSResponse
+    {
+        public string Url;
+    }
+
 }


### PR DESCRIPTION
This PR:
- Fixes #32 
- Sends files through presigned url rather than direct hits to BugSplat's file upload api

To be addressed before acceptance:

- [x] Added functions require e2e tests
- [x] Testing the /commitS3CrashUpload endpoint has resulted in a mismatched md5 from server. I'm wondering if this is something wrong with the request configuration.